### PR TITLE
Fix footstep_planner node crashes when map changes

### DIFF
--- a/footstep_planner/src/PathCostHeuristic.cpp
+++ b/footstep_planner/src/PathCostHeuristic.cpp
@@ -134,6 +134,9 @@ PathCostHeuristic::calculateDistances(const PlanningState& from,
 void
 PathCostHeuristic::updateMap(gridmap_2d::GridMap2DPtr map)
 {
+  if (ivpGrid) // reset map before change it's sizes (in other case we will get SEGMENT ERROR)
+    resetGrid();
+
   ivMapPtr.reset();
   ivMapPtr = map;
 
@@ -146,8 +149,7 @@ PathCostHeuristic::updateMap(gridmap_2d::GridMap2DPtr map)
     ivGridSearchPtr->destroy();
   ivGridSearchPtr.reset(new SBPL2DGridSearch(width, height,
                                              ivMapPtr->getResolution()));
-  if (ivpGrid)
-    resetGrid();
+
   ivpGrid = new unsigned char* [width];
 
   for (unsigned x = 0; x < width; ++x)
@@ -171,8 +173,9 @@ PathCostHeuristic::updateMap(gridmap_2d::GridMap2DPtr map)
 void
 PathCostHeuristic::resetGrid()
 {
-  CvSize size = ivMapPtr->size();
-  for (int x = 0; x < size.width; ++x)
+  // CvSize size = ivMapPtr->size(); // here we get (height; width) instead of (width; height)
+  int width = ivMapPtr->getInfo().width;
+  for (int x = 0; x < width; ++x)
   {
     if (ivpGrid[x])
     {


### PR DESCRIPTION
Crashes were issued by **wrong memory deallocation**
* In memory deallocation were used sizes of new map (it can be bigger)
And then node falls.
* Also in memory deallocation method was used height instead of width.
-----
Some screenshots of debugging included.
Check locals in debug window:  
`width_before` and `width_after` are sizes of old map, `width`, `height` - sizes of new map, which will be used for deallocation of old map memory.
![screenshot from 2017-02-18 15 37 09](https://cloud.githubusercontent.com/assets/9571479/23368688/acb16708-fd1f-11e6-824e-145c2864f8a6.png)

-------
And where it fails (memory deallocation). Also there was used height instead of width
![screenshot from 2017-02-18 15 37 33](https://cloud.githubusercontent.com/assets/9571479/23368694/af666192-fd1f-11e6-9ba1-5122a9100375.png)

*P.S. This version also works with Ros Jade*